### PR TITLE
メール送信失敗時にログを残す

### DIFF
--- a/assets/snippets/cfFormMailer/class.cfFormMailer.inc.php
+++ b/assets/snippets/cfFormMailer/class.cfFormMailer.inc.php
@@ -826,7 +826,11 @@ class Class_cfFormMailer {
    * @return string 認証コード画像の URI
    */
   function getCaptchaUri() {
-    return $this->modx->config['base_url'] . 'manager/includes/veriword.php?tmp=' . rand();
+    if(is_file($this->modx->config['base_path'] . 'captcha.php'))
+      $captchalib = 'captcha.php';
+    else
+      $captchalib = 'manager/includes/veriword.php?tmp=' . mt_rand();
+    return $this->modx->config['base_url']  . $captchalib;
   }
 
   /**


### PR DESCRIPTION
メールを送信しようとしたらエラーが出たとのことなので、調べてみました。結局それは自分の設定ミスでしたが、送信に失敗した時にログを残しておけたら便利と思いました。1.0.5J-r11ではログ記録時に管理者宛てにエラー発生通知メールを自動送信できます
