### PR TITLE
環境設定項目admin_nameでフィールド名を指定可能にする

### DIFF
--- a/assets/snippets/cfFormMailer/class.cfFormMailer.inc.php
+++ b/assets/snippets/cfFormMailer/class.cfFormMailer.inc.php
@@ -524,7 +524,13 @@ class Class_cfFormMailer {
     $subject = (ADMIN_SUBJECT) ? ADMIN_SUBJECT : "サイトから送信されたメール";
     $pm->Subject = $this->_encodeMimeHeader($subject, $mailCharset);
     if (defined('ADMIN_NAME') && ADMIN_NAME) {
-      $pm->FromName = $this->_encodeMimeHeader(ADMIN_NAME, $mailCharset, false);
+        $admin_name = '';
+        $tmp = explode('+', ADMIN_NAME);
+        foreach ($tmp as $_) {
+            $_ = trim($_);
+            $admin_name .= (!$this->form[$_]) ? $_ : $this->form[$_];
+        }
+        $pm->FromName = $this->_encodeMimeHeader($admin_name, $mailCharset, false);
     } else {
       $pm->FromName = '';
     }


### PR DESCRIPTION
&lt;input type=&quot;text&quot; name=&quot;onamae&quot; value=&quot;&quot; /&gt;
という場合に
admin_name = onamae+様
という感じで指定可
（従来どおりの使い方も可）
