### PR TITLE
1.0.15J以降モディファイアが無効になるため修正

### DIFF
--- a/assets/snippets/cfFormMailer/class.cfFormMailer.inc.php
+++ b/assets/snippets/cfFormMailer/class.cfFormMailer.inc.php
@@ -905,9 +905,11 @@ function convertjp($text)
     preg_match_all("/\[\+([^\+\|]+)(\|(.*?)(\((.+?)\))?)?\+\]/is", $text, $match, PREG_SET_ORDER);
     if (!count($match)) return $text;
 
-    if(isset($modx->config['output_filter'])&&$modx->config['output_filter']!=='0')
-        $toFilter = true;
-    else $toFilter = false;
+    //1.0.15J以降 $modx->config['output_filter']は廃止
+    $toFilter = true;
+    //旧バージョン用
+    if(isset($modx->config['output_filter']) &&$modx->config['output_filter']==='0') $toFilter = false;
+
     if($toFilter) $modx->loadExtension('PHx') or die('Could not load PHx class.');
     
     // 基本プレースホルダ


### PR DESCRIPTION
こんにちは。
新しいバージョンで利用する際，$modx->config['output_filter']廃止による影響で，
ifemptyなどのモディファイアが利用できず困ってしまいましたので，修正案です。
取り込んでおいて頂けると幸いです。
c.f.
http://modx.jp/news/evolution/20151230.html
